### PR TITLE
Style widget live activity

### DIFF
--- a/MindfulBooWidget/Info.plist
+++ b/MindfulBooWidget/Info.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
+        <key>NSExtension</key>
+        <dict>
+                <key>NSExtensionPointIdentifier</key>
+                <string>com.apple.widgetkit-extension</string>
+                <key>NSSupportsLiveActivities</key>
+                <true/>
+        </dict>
 </dict>
 </plist>

--- a/MindfulBooWidget/MindfulBooWidgetLiveActivity.swift
+++ b/MindfulBooWidget/MindfulBooWidgetLiveActivity.swift
@@ -28,27 +28,63 @@ enum SessionState: String, Codable, Hashable {
     case ended
 }
 
+struct GradientProgressBar: View {
+    var progress: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.2))
+                    .frame(height: 6)
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            gradient: Gradient(colors: [.green, .blue]),
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: geometry.size.width * CGFloat(progress), height: 6)
+            }
+        }
+        .frame(height: 6)
+    }
+}
+
 struct MindfulBooWidgetLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: MindfulBooActivityAttributes.self) { context in
             // Lock screen/banner UI
-            VStack(spacing: 16) {
-                HStack {
+            VStack(spacing: 12) {
+                HStack(spacing: 8) {
                     Image(systemName: "lotus")
                         .font(.title2)
-                    Text("MindfulBoo Session")
+                    Text("MindfulBoo")
                         .font(.headline)
+                        .fontWeight(.semibold)
                 }
-                
-                ProgressView(value: context.state.progress)
-                    .progressViewStyle(.linear)
-                
+                .foregroundColor(.white)
+
+                GradientProgressBar(progress: context.state.progress)
+
                 Text(timerInterval: Date.now...Date.now.addingTimeInterval(context.state.timeRemaining), countsDown: true)
-                    .font(.largeTitle)
-                    .fontWeight(.semibold)
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .monospacedDigit()
+                    .foregroundColor(.white)
             }
             .padding()
-            .activityBackgroundTint(Color.black.opacity(0.5))
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: [.green, .blue]),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .opacity(0.9)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .activityBackgroundTint(Color.clear)
             .activitySystemActionForegroundColor(Color.white)
 
         } dynamicIsland: { context in
@@ -64,9 +100,8 @@ struct MindfulBooWidgetLiveActivity: Widget {
                         .fontWeight(.semibold)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    ProgressView(value: context.state.progress)
-                        .progressViewStyle(.linear)
-                        .tint(.white)
+                    GradientProgressBar(progress: context.state.progress)
+                        .frame(maxWidth: .infinity)
                 }
             } compactLeading: {
                 Image(systemName: "lotus")

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ A simple and fast meditation app for iOS.
 3. Select your development team
 4. Build and run
 
+## Testing Live Activities
+
+Live Activities require a physical device running iOS 16.1 or later. The iOS simulator does not support them, so run the app on an actual device when testing the `MindfulBooWidget` live activity extension.
+
 ## Usage
 
 1. **Start Session**: Set duration and tap "Start Meditation"


### PR DESCRIPTION
## Summary
- style the lock screen Live Activity with gradient colors
- add a custom progress bar for the widget

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687a5df2db9c83268ee82345dc1854b3