### PR TITLE
Fix dismissal of Live Activity

### DIFF
--- a/MindfulBoo/MindfulBoo/AllTypes.swift
+++ b/MindfulBoo/MindfulBoo/AllTypes.swift
@@ -489,7 +489,7 @@ class SessionManager: ObservableObject {
         )
         
         Task {
-            await currentActivity?.end(using: finalState, dismissalPolicy: .default)
+            await currentActivity?.end(using: finalState, dismissalPolicy: .immediate)
             print("Live Activity ended")
         }
     }


### PR DESCRIPTION
## Summary
- end the live activity immediately at session completion

## Testing
- `xcodebuild -list -project MindfulBoo.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687a739a51b883269c44d1d0338583c9